### PR TITLE
Use v2 of ubuntu18-postgres11 to get UTF8 fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kwhadocker/ubuntu18-postgres11:latest
+FROM kwhadocker/ubuntu18-postgres11:v2
 
 # Move to root
 WORKDIR /root/


### PR DESCRIPTION
Same fix as for our insurance-requirements docker image (https://github.com/kwhanalytics/insurance-requirements/pull/15) . 

Making the same fix here in the data-env (Python 3) image.