### PR TITLE
add Altair to insurance requirements

### DIFF
--- a/insurance-requirements.txt
+++ b/insurance-requirements.txt
@@ -1,4 +1,5 @@
 alembic==0.7.6
+altair==3.3.0
 appnope==0.1.0
 astroid==1.2.0
 attrs==19.1.0


### PR DESCRIPTION
Insurance reporting code imports from a marvin subrepo file that imports altair requires that altair be installed. I notice that `marvin-requirements.txt` does not already include this module. Perhaps this would be a better place.