### PR TITLE
Add markdown v3.2.2 to insurance-requirements

### DIFF
--- a/insurance-requirements.txt
+++ b/insurance-requirements.txt
@@ -57,7 +57,6 @@ jupyter-console==5.2.0
 jupyter-core==4.4.0
 logilab-common==0.62.1
 Mako==1.0.1
-Markdown==3.2.2
 MarkupSafe==0.23
 matplotlib==1.5.3
 mccabe==0.6.1

--- a/insurance-requirements.txt
+++ b/insurance-requirements.txt
@@ -57,6 +57,7 @@ jupyter-console==5.2.0
 jupyter-core==4.4.0
 logilab-common==0.62.1
 Mako==1.0.1
+Markdown==3.2.2
 MarkupSafe==0.23
 matplotlib==1.5.3
 mccabe==0.6.1

--- a/insurance-requirements.txt
+++ b/insurance-requirements.txt
@@ -10,7 +10,6 @@ beautifulsoup4==4.6.0
 bleach==3.1.0
 boto==2.46.1
 boto3==1.7.17
-botocore==1.10.84
 cairocffi==0.9.0
 CairoSVG==1.0.22
 certifi==2019.3.9
@@ -106,7 +105,6 @@ pyshp==2.1.0
 python-dateutil==2.8.0
 python-Levenshtein==0.12.0
 pytz==2017.2
-PyYAML==5.1.2
 pyzmq==18.0.1
 qtconsole==4.4.3
 requests==2.20.0

--- a/marvin-requirements.txt
+++ b/marvin-requirements.txt
@@ -7,7 +7,6 @@ beaker==1.10.0
 beautifulsoup4==4.6.0
 boto==2.46.1
 boto3==1.7.17
-botocore==1.10.84
 cffi==1.10.0
 configparser==3.7.4
 coverage==4.4.1
@@ -55,7 +54,6 @@ python-dateutil==2.8.0
 python-Levenshtein==0.12.0
 python-slugify==4.0.0
 pytz==2017.2
-PyYAML==5.1.2
 requests==2.20.0
 ruamel.yaml==0.16.10
 s3transfer==0.1.13

--- a/marvin-requirements.txt
+++ b/marvin-requirements.txt
@@ -1,7 +1,7 @@
 alembic==0.7.6
 altair==3.3.0
 altgraph==0.16.1
-awscli==1.18.205
+awscli==1.15.60
 astroid==1.2.0
 beaker==1.10.0
 beautifulsoup4==4.6.0

--- a/marvin-requirements.txt
+++ b/marvin-requirements.txt
@@ -1,7 +1,7 @@
 alembic==0.7.6
 altair==3.3.0
 altgraph==0.16.1
-awscli==1.15.60
+awscli==1.18.205
 astroid==1.2.0
 beaker==1.10.0
 beautifulsoup4==4.6.0


### PR DESCRIPTION
To support markdown notes for policies in the policy review report.
https://bitbucket.org/kwh/insurance/pull-requests/1433