### PR TITLE
switch camelot-py -> camelot-py[cv]

### DIFF
--- a/marvin-requirements.txt
+++ b/marvin-requirements.txt
@@ -7,7 +7,7 @@ beaker==1.10.0
 beautifulsoup4==4.6.0
 boto==2.46.1
 boto3==1.7.17
-camelot-py==0.7.3
+camelot-py[cv]==0.7.3
 cffi==1.10.0
 configparser==3.7.4
 coverage==4.4.1


### PR DESCRIPTION
Fixes: 
`ImportError: No module named 'cv2'`
https://pipeline.kwhanalytics.com/teams/main/pipelines/partnership-clearway-marvin-4763/jobs/partnership-clearway-marvin-4763/builds/7