### PR TITLE
V13 - bump psycopg2 to 2.8.6, remove binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update && apt-get install -y \
         libffi-dev \
         python-dev \
         chromium-chromedriver \
+        ghostscript \
         python-tk \
         python3-tk \
         python-pip \

--- a/marvin-requirements.txt
+++ b/marvin-requirements.txt
@@ -42,8 +42,7 @@ patsy==0.5.1
 pbr==1.8.1
 pdfminer.six==20191110
 psutil==3.2.2
-psycopg2==2.7.4
-psycopg2-binary==2.7.4
+psycopg2==2.8.6
 pvlib==0.6.1
 pycodestyle==2.5.0
 pycparser==2.17

--- a/marvin-requirements.txt
+++ b/marvin-requirements.txt
@@ -9,6 +9,7 @@ boto==2.46.1
 boto3==1.7.17
 camelot-py[cv]==0.7.3
 cffi==1.10.0
+click==7.1.2
 configparser==3.7.4
 coverage==4.4.1
 deepdiff==3.3.0
@@ -27,6 +28,7 @@ geopy==1.10.0
 jdcal==1.4.1
 jmespath==0.9.4
 logilab-common==0.62.1
+loguru==0.5.3
 Mako==1.0.1
 MarkupSafe==0.23
 matplotlib==1.5.3


### PR DESCRIPTION
This seems to be necessary for compatibility with M1 macs.

It is actually recommended not to use the binary in production environments anyways:
https://pypi.org/project/psycopg2-binary/